### PR TITLE
fix overflow in size calculation

### DIFF
--- a/include/dedispersionlite.h
+++ b/include/dedispersionlite.h
@@ -75,15 +75,15 @@ namespace Pulsar
 			databuffer.counter += ndump;
 		}
 	public:
-		int nsubband;
+		long int nsubband;
 		vector<double> vdm;
 	public:
 		long int counter;
 		long int offset;
-		int nchans;
+		long int nchans;
 		double tsamp;
-		int ndump;
-		int nsamples;
+		long int ndump;
+		long int nsamples;
 		vector<double> frequencies;
 		vector<long int> delayn;
 		vector<float> buffer;

--- a/include/dedispersionliteU.h
+++ b/include/dedispersionliteU.h
@@ -82,10 +82,10 @@ namespace Pulsar
 	public:
 		long int counter;
 		long int offset;
-		int nchans;
+		long int nchans;
 		double tsamp;
-		int ndump;
-		int nsamples;
+		long int ndump;
+		long int nsamples;
 		vector<double> frequencies;
 		vector<long int> delayn;
 		vector<float> buffer;

--- a/src/pulsar/psrfold_fil.cpp
+++ b/src/pulsar/psrfold_fil.cpp
@@ -549,7 +549,7 @@ int main(int argc, const char *argv[])
 	 */
 	int ngroup = dmsegs.size();
 
-	int nleft = dedisp.offset/dedisp.ndump;
+	long int nleft = dedisp.offset/dedisp.ndump;
 	for (long int l=0; l<nleft; l++)
 	{
 		rfi.open();

--- a/src/pulsar/psrfold_fil2.cpp
+++ b/src/pulsar/psrfold_fil2.cpp
@@ -621,13 +621,13 @@ int main(int argc, const char *argv[])
 	 * 
 	 */
 
-	std::vector<int> nlefts(ncand, 0);
+	std::vector<long int> nlefts(ncand, 0);
 	for (long int k=0; k<ncand; k++)
 	{
 		nlefts[k] = dedisp.get_offset(folder[k].dm)/dedisp.get_ndump(folder[k].dm);
 	}
 
-	int nleft_max = *std::max_element(nlefts.begin(), nlefts.end());
+	long int nleft_max = *std::max_element(nlefts.begin(), nlefts.end());
 
 	for (long int l=0; l<nleft_max; l++)
 	{


### PR DESCRIPTION
`int` overflow is encountered when folding 21CMA data (tsamp = 160 us, nchan = 24576, f = 50-200 MHz) for PSR B0329+54 (DM = 26.76 => delay = 41.64 s), DM delay size of that is ~6.4 * 10^9 , so it requires `long int`. (Actually `size_t` should be better for sizes.)